### PR TITLE
Add support for repository variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for Github Actions variables via `var.variables`
+
+### Changed
+
+- Bumped provider min version to `v5.19`
+
 ## [0.18.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -854,6 +854,29 @@ This is due to some terraform limitation and we will update the module once terr
 
     Determines whether the SSL certificate of the host for `url` will be verified when delivering payloads. Supported values include `0` (verification is performed) and `1` (verification is not performed). The default is `0`. **We strongly recommend not setting this to `1` as you are subject to man-in-the-middle and other attacks.**
 
+#### Variables Configuration
+
+- [**`variables`**](#var-variables): *(Optional `map(string)`)*<a name="var-variables"></a>
+
+  Map of Github Action variables to create for this repository.
+
+  Each key, value pair maps directly to a `vars` context key, and
+  any restrictions Github places on variable naming will be reflected
+  within this map, too.
+
+  You can have a maximum of 500 variables per repository, and each variable's
+  value may be no larger than 48KB.
+
+  Default is `{}`.
+
+  Example:
+
+  ```hcl
+  variables = {
+    MY_REPO_VARIABLE = "my-repo-variable-value"
+  }
+  ```
+
 #### Secrets Configuration
 
 - [**`plaintext_secrets`**](#var-plaintext_secrets): *(Optional `map(string)`)*<a name="var-plaintext_secrets"></a>

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1127,6 +1127,31 @@ section {
       }
 
       section {
+        title = "Variables Configuration"
+
+        variable "variables" {
+          type = map(string)
+          default = {}
+          description = <<-END
+            Map of Github Action variables to create for this repository.
+
+            Each key, value pair maps directly to a `vars` context key, and
+            any restrictions Github places on variable naming will be reflected
+            within this map, too.
+
+            You can have a maximum of 500 variables per repository, and each variable's
+            value may be no larger than 48KB.
+          END
+
+          readme_example = <<-END
+            variables = {
+              MY_REPO_VARIABLE = "my-repo-variable-value"
+            }
+          END
+        }
+      }
+
+      section {
         title = "Secrets Configuration"
 
         variable "plaintext_secrets" {

--- a/repo_vars.tf
+++ b/repo_vars.tf
@@ -1,0 +1,15 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Action Variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+locals {
+  action_variables = var.variables
+}
+
+resource "github_actions_variable" "repository_variable" {
+  for_each = local.action_variables
+
+  repository    = github_repository.repository.id
+  variable_name = each.key
+  value         = each.value
+}

--- a/variables.tf
+++ b/variables.tf
@@ -494,6 +494,25 @@ variable "webhooks" {
   # }]
 }
 
+variable "variables" {
+  description = "(Optional) Configure action variables. For full details please check: https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable"
+  type        = map(string)
+
+  default = {}
+
+  validation {
+    condition     = length(var.variables) > 500
+    error_message = "Github restricts the number of Action variables per repository to 500"
+  }
+
+  validation {
+    condition = anytrue([
+      for _, v in var.variables : length(v) > 48 * 1000
+    ])
+    error_message = "Github restricts the maximum size of a single Action variable to 48KB"
+  }
+}
+
 variable "plaintext_secrets" {
   description = "(Optional) Configuring actions secrets. For details please check: https://www.terraform.io/docs/providers/github/r/actions_secret"
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 4.20, < 6.0"
+      version = ">= 5.19, < 6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Extends the module to allow for the creation of [actions_variable](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_variable)s.

The use case I have in mind is extending support for an downstream module that includes org variables, so that I can expose an interface for creating repo specific variables in addition to org variables.

I haven't run any of the CI stuff beyond a local `tf fmt / validate` as I think this fork is still early days and quite strongly coupled to the upstream's CI.

## Changelog

```
2023-08-09  Paul Stemmet  <paul.stemmet@amach.ie>

	chore: update CHANGELOG

	doc: update README for var.variables
	Note that I have manually updated the .md file, as I cannot find a
	terradoc binary.

2023-08-09  Paul Stemmet  <paul.stemmet@amach.ie>

	feat: add support for github_actions_variables
	Add support for creating Github Actions variables through the module.

	This simply extends the module to use the `github_actions_variable`
	resource provided by integrations/github.

	We also add some limit validations based on the upstream documentation,
	so as to try and catch failures before applies.

	References: https://docs.github.com/en/actions/learn-github-actions/contexts#vars-context
	References: https://docs.github.com/en/actions/learn-github-actions/variables#limits-for-configuration-variables

2023-08-09  Paul Stemmet  <paul.stemmet@amach.ie>

	chore: bump version min to v5.19
	From v4.20, to support the usage of the action_variable resource
	(included in v5.18.3)

	References: https://github.com/integrations/terraform-provider-github/releases/tag/v5.18.3
	References: https://github.com/integrations/terraform-provider-github/pull/1569
```
