### PR TITLE
chore(versions): update integrations/github to >=6.0,<7.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = ">= 5.19, < 6.0"
+      version = ">= 6.0, < 7.0"
     }
   }
 }


### PR DESCRIPTION
So as to keep current, and give us access to the latest and greatest from our underlying provider.
