### PR TITLE
fork: fix upstream links, refs; update license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ If everything looks good, they will merge the code and release a new version whi
 
 <!-- References -->
 
-[pull requests]: https://github.com/mineiros-io/terraform-github-repository/pulls
-[pre-commit-file]: https://github.com/mineiros-io/terraform-github-repository/blob/main/.pre-commit-config.yaml
+[pull requests]: https://github.com/amachsoftware/terraform-github-repository/pulls
+[pre-commit-file]: https://github.com/amachsoftware/terraform-github-repository/blob/main/.pre-commit-config.yaml
 [github flow]: https://guides.github.com/introduction/flow/
 [codeowners]: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 [fork]: https://help.github.com/en/github/getting-started-with-github/fork-a-repo

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2020] [mineiros.io]
+   Copyright [2020-2023] [mineiros.io],
+   Copyright [2024] [amach.com]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,7 @@ Run `make help` to see details on each available target.
 This module is licensed under the Apache License Version 2.0, January 2004.
 Please see [LICENSE] for full details.
 
-Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
+Copyright &copy; 2020-2023 Mineiros GmbH, 2024 [Amach][homepage]
 
 
 <!-- References -->

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>](https://mineiros.io/?ref=terraform-github-repository)
+[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>](https://amach.com)
 
-[![Build Status](https://github.com/mineiros-io/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/mineiros-io/terraform-github-repository/actions)
-[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver)](https://github.com/mineiros-io/terraform-github-repository/releases)
+[![Build Status](https://github.com/amachsoftware/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/amachsoftware/terraform-github-repository/actions)
+[![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver)](https://github.com/amachsoftware/terraform-github-repository/releases)
 [![Terraform Version](https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform)](https://github.com/hashicorp/terraform/releases)
 [![Github Provider Version](https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform)](https://github.com/terraform-providers/terraform-provider-github/releases)
-[![Join Slack](https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack)](https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg)
 
 # terraform-github-repository
 
@@ -17,7 +16,6 @@ A [Terraform] module for creating a public or private repository on [Github].
 ** Note: Versions 5.3.0, 5.4.0, and 5.5.0 of the Terraform Github Provider have broken branch protections support and should not be used.**
 
 
-- [GitHub as Code](#github-as-code)
 - [Module Features](#module-features)
 - [Getting Started](#getting-started)
 - [Module Argument Reference](#module-argument-reference)
@@ -33,6 +31,7 @@ A [Terraform] module for creating a public or private repository on [Github].
     - [Issue Labels Configuration](#issue-labels-configuration)
     - [Projects Configuration](#projects-configuration)
     - [Webhooks Configuration](#webhooks-configuration)
+    - [Variables Configuration](#variables-configuration)
     - [Secrets Configuration](#secrets-configuration)
     - [Autolink References Configuration](#autolink-references-configuration)
     - [App Installations](#app-installations)
@@ -42,27 +41,11 @@ A [Terraform] module for creating a public or private repository on [Github].
   - [Terraform Github Provider Documentation](#terraform-github-provider-documentation)
 - [Module Versioning](#module-versioning)
   - [Backwards compatibility in `0.0.z` and `0.y.z` version](#backwards-compatibility-in-00z-and-0yz-version)
-- [About Mineiros](#about-mineiros)
+- [About Amach](#about-amach)
 - [Reporting Issues](#reporting-issues)
 - [Contributing](#contributing)
 - [Makefile Targets](#makefile-targets)
 - [License](#license)
-
-## GitHub as Code
-
-[GitHub as Code][github-as-code] is a commercial solution built on top of
-our open-source Terraform modules for GitHub. It helps our customers to
-manage their GitHub organization more efficiently by enabling anyone in
-their organization to **self-service** manage **on- and offboarding of users**,
-**repositories**, and settings such as **branch protections**, **secrets**, and more
-through code. GitHub as Code comes with **pre-configured GitHub Actions
-pipelines** for **change pre-view in Pull Requests**, **fully automated
-rollouts** and **rollbacks**. It's a comprehensive, ready-to-use blueprint
-maintained by our team of platform engineering experts and saves
-companies such as yours tons of time by building on top of a pre-configured
-solution instead of building and maintaining it yourself.
-
-For details please see [https://mineiros.io/github-as-code][github-as-code].
 
 ## Module Features
 
@@ -103,7 +86,7 @@ Most basic usage creating a new private github repository.
 
 ```hcl
 module "repository" {
-  source  = "mineiros-io/repository/github"
+  source  = "amachsoftware/repository/github"
   version = "~> 0.18.0"
 
   name               = "terraform-github-repository"
@@ -1068,17 +1051,21 @@ Given a version number `MAJOR.MINOR.PATCH`, we increment the:
 - Backwards compatibility in versions `0.0.z` is **not guaranteed** when `z` is increased. (Initial development)
 - Backwards compatibility in versions `0.y.z` is **not guaranteed** when `y` is increased. (Pre-release)
 
-## About Mineiros
+## About Amach
 
-[Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
-that solves development, automation and security challenges in cloud infrastructure.
+[Amach][homepage]
 
-Our vision is to massively reduce time and overhead for teams to manage and
-deploy production-grade and secure cloud infrastructure.
+Cloud experts around the world. Delivering quality solutions.
 
-We offer commercial support for all of our modules and encourage you to reach out
-if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
-[Community Slack channel][slack].
+From day 1, we have focused on finding the very best talent to drive us
+forward.
+
+At our heart, we are a team of Engineers who love problem-solving while
+focusing on the quality of what we deliver.
+
+We believe that infrastructure as code empowers organizations to provide
+development teams direct access to infrastructure resources, thereby
+fulfilling the spirit of DevOps.
 
 ## Reporting Issues
 
@@ -1112,28 +1099,24 @@ Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
 [`github_repository_deploy_key`]: https://www.terraform.io/docs/providers/github/r/repository_deploy_key.html#attributes-reference
 [`github_repository_project`]: https://www.terraform.io/docs/providers/github/r/repository_project.html#attributes-reference
 [`github_repository_autolink_reference`]: https://www.terraform.io/docs/providers/github/r/repository_autolink_reference.html#attributes-reference
-[homepage]: https://mineiros.io/?ref=terraform-github-repository
-[github-as-code]: https://mineiros.io/github-as-code?ref=terraform-github-repository
-[hello@mineiros.io]: mailto:hello@mineiros.io
-[badge-build]: https://github.com/mineiros-io/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg
-[badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver
+[homepage]: https://amach.com
+[badge-build]: https://github.com/amachsoftware/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg
+[badge-semver]: https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
-[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [badge-tf-gh]: https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform
 [releases-github-provider]: https://github.com/terraform-providers/terraform-provider-github/releases
-[build-status]: https://github.com/mineiros-io/terraform-github-repository/actions
-[releases-github]: https://github.com/mineiros-io/terraform-github-repository/releases
+[build-status]: https://github.com/amachsoftware/terraform-github-repository/actions
+[releases-github]: https://github.com/amachsoftware/terraform-github-repository/releases
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0
-[slack]: https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg
 [terraform]: https://www.terraform.io
 [aws]: https://aws.amazon.com/
 [semantic versioning (semver)]: https://semver.org/
-[variables.tf]: https://github.com/mineiros-io/terraform-github-repository/blob/main/variables.tf
-[examples/]: https://github.com/mineiros-io/terraform-github-repository/blob/main/examples
-[issues]: https://github.com/mineiros-io/terraform-github-repository/issues
-[license]: https://github.com/mineiros-io/terraform-github-repository/blob/main/LICENSE
-[makefile]: https://github.com/mineiros-io/terraform-github-repository/blob/main/Makefile
-[pull requests]: https://github.com/mineiros-io/terraform-github-repository/pulls
-[contribution guidelines]: https://github.com/mineiros-io/terraform-github-repository/blob/main/CONTRIBUTING.md
+[variables.tf]: https://github.com/amachsoftware/terraform-github-repository/blob/main/variables.tf
+[examples/]: https://github.com/amachsoftware/terraform-github-repository/blob/main/examples
+[issues]: https://github.com/amachsoftware/terraform-github-repository/issues
+[license]: https://github.com/amachsoftware/terraform-github-repository/blob/main/LICENSE
+[makefile]: https://github.com/amachsoftware/terraform-github-repository/blob/main/Makefile
+[pull requests]: https://github.com/amachsoftware/terraform-github-repository/pulls
+[contribution guidelines]: https://github.com/amachsoftware/terraform-github-repository/blob/main/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>](https://amach.com)
+[<img src="https://repository-images.githubusercontent.com/662075696/23600e8a-7d2b-4f5c-aa58-afd28d01f056" width="400"/>](https://amach.com)
 
 [![Build Status](https://github.com/amachsoftware/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg)](https://github.com/amachsoftware/terraform-github-repository/actions)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver)](https://github.com/amachsoftware/terraform-github-repository/releases)

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1,16 +1,16 @@
 header {
   image = "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg"
-  url   = "https://mineiros.io/?ref=terraform-github-repository"
+  url   = "https://amach.com"
 
   badge "build" {
-    image = "https://github.com/mineiros-io/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg"
-    url   = "https://github.com/mineiros-io/terraform-github-repository/actions"
+    image = "https://github.com/amachsoftware/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg"
+    url   = "https://github.com/amachsoftware/terraform-github-repository/actions"
     text  = "Build Status"
   }
 
   badge "semver)" {
-    image = "https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver"
-    url   = "https://github.com/mineiros-io/terraform-github-repository/releases"
+    image = "https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver"
+    url   = "https://github.com/amachsoftware/terraform-github-repository/releases"
     text  = "GitHub tag (latest SemVer)"
   }
 
@@ -24,12 +24,6 @@ header {
     image = "https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform"
     url   = "https://github.com/terraform-providers/terraform-provider-github/releases"
     text  = "Github Provider Version"
-  }
-
-  badge "slack" {
-    image = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
-    url   = "https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg"
-    text  = "Join Slack"
   }
 }
 
@@ -45,25 +39,6 @@ section {
 
     ** Note: Versions 5.3.0, 5.4.0, and 5.5.0 of the Terraform Github Provider have broken branch protections support and should not be used.**
   END
-
-  section {
-    title   = "GitHub as Code"
-    content = <<-END
-      [GitHub as Code][github-as-code] is a commercial solution built on top of
-      our open-source Terraform modules for GitHub. It helps our customers to
-      manage their GitHub organization more efficiently by enabling anyone in
-      their organization to **self-service** manage **on- and offboarding of users**,
-      **repositories**, and settings such as **branch protections**, **secrets**, and more
-      through code. GitHub as Code comes with **pre-configured GitHub Actions
-      pipelines** for **change pre-view in Pull Requests**, **fully automated
-      rollouts** and **rollbacks**. It's a comprehensive, ready-to-use blueprint
-      maintained by our team of platform engineering experts and saves
-      companies such as yours tons of time by building on top of a pre-configured
-      solution instead of building and maintaining it yourself.
-
-      For details please see [https://mineiros.io/github-as-code][github-as-code].
-    END
-  }
 
   section {
     title   = "Module Features"
@@ -108,7 +83,7 @@ section {
 
       ```hcl
       module "repository" {
-        source  = "mineiros-io/repository/github"
+        source  = "amachsoftware/repository/github"
         version = "~> 0.18.0"
 
         name               = "terraform-github-repository"
@@ -1422,17 +1397,21 @@ section {
   }
 
   section {
-    title   = "About Mineiros"
+    title   = "About Amach"
     content = <<-END
-      [Mineiros][homepage] is a remote-first company headquartered in Berlin, Germany
-      that solves development, automation and security challenges in cloud infrastructure.
+      [Amach][homepage]
 
-      Our vision is to massively reduce time and overhead for teams to manage and
-      deploy production-grade and secure cloud infrastructure.
+      Cloud experts around the world. Delivering quality solutions.
 
-      We offer commercial support for all of our modules and encourage you to reach out
-      if you have any questions or need help. Feel free to email us at [hello@mineiros.io] or join our
-      [Community Slack channel][slack].
+      From day 1, we have focused on finding the very best talent to drive us
+      forward.
+
+      At our heart, we are a team of Engineers who love problem-solving while
+      focusing on the quality of what we deliver.
+
+      We believe that infrastructure as code empowers organizations to provide
+      development teams direct access to infrastructure resources, thereby
+      fulfilling the spirit of DevOps.
     END
   }
 
@@ -1492,28 +1471,19 @@ references {
     value = "https://www.terraform.io/docs/providers/github/r/repository_autolink_reference.html#attributes-reference"
   }
   ref "homepage" {
-    value = "https://mineiros.io/?ref=terraform-github-repository"
-  }
-  ref "github-as-code" {
-    value = "https://mineiros.io/github-as-code?ref=terraform-github-repository"
-  }
-  ref "hello@mineiros.io" {
-    value = "mailto:hello@mineiros.io"
+    value = "https://amach.com"
   }
   ref "badge-build" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg"
+    value = "https://github.com/amachsoftware/terraform-github-repository/workflows/CI/CD%20Pipeline/badge.svg"
   }
   ref "badge-semver" {
-    value = "https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver"
+    value = "https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver"
   }
   ref "badge-license" {
     value = "https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg"
   }
   ref "badge-terraform" {
     value = "https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform"
-  }
-  ref "badge-slack" {
-    value = "https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack"
   }
   ref "badge-tf-gh" {
     value = "https://img.shields.io/badge/GH-4.10+-F8991D.svg?logo=terraform"
@@ -1522,19 +1492,16 @@ references {
     value = "https://github.com/terraform-providers/terraform-provider-github/releases"
   }
   ref "build-status" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/actions"
+    value = "https://github.com/amachsoftware/terraform-github-repository/actions"
   }
   ref "releases-github" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/releases"
+    value = "https://github.com/amachsoftware/terraform-github-repository/releases"
   }
   ref "releases-terraform" {
     value = "https://github.com/hashicorp/terraform/releases"
   }
   ref "apache20" {
     value = "https://opensource.org/licenses/Apache-2.0"
-  }
-  ref "slack" {
-    value = "https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg"
   }
   ref "terraform" {
     value = "https://www.terraform.io"
@@ -1546,24 +1513,24 @@ references {
     value = "https://semver.org/"
   }
   ref "variables.tf" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/blob/main/variables.tf"
+    value = "https://github.com/amachsoftware/terraform-github-repository/blob/main/variables.tf"
   }
   ref "examples/" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/blob/main/examples"
+    value = "https://github.com/amachsoftware/terraform-github-repository/blob/main/examples"
   }
   ref "issues" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/issues"
+    value = "https://github.com/amachsoftware/terraform-github-repository/issues"
   }
   ref "license" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/blob/main/LICENSE"
+    value = "https://github.com/amachsoftware/terraform-github-repository/blob/main/LICENSE"
   }
   ref "makefile" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/blob/main/Makefile"
+    value = "https://github.com/amachsoftware/terraform-github-repository/blob/main/Makefile"
   }
   ref "pull requests" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/pulls"
+    value = "https://github.com/amachsoftware/terraform-github-repository/pulls"
   }
   ref "contribution guidelines" {
-    value = "https://github.com/mineiros-io/terraform-github-repository/blob/main/CONTRIBUTING.md"
+    value = "https://github.com/amachsoftware/terraform-github-repository/blob/main/CONTRIBUTING.md"
   }
 }

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1446,7 +1446,7 @@ section {
       This module is licensed under the Apache License Version 2.0, January 2004.
       Please see [LICENSE] for full details.
 
-      Copyright &copy; 2020-2022 [Mineiros GmbH][homepage]
+      Copyright &copy; 2020-2023 Mineiros GmbH, 2024 [Amach][homepage]
     END
   }
 }

--- a/README.tfdoc.hcl
+++ b/README.tfdoc.hcl
@@ -1,5 +1,5 @@
 header {
-  image = "https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg"
+  image = "https://repository-images.githubusercontent.com/662075696/23600e8a-7d2b-4f5c-aa58-afd28d01f056"
   url   = "https://amach.com"
 
   badge "build" {

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+[<img src="https://repository-images.githubusercontent.com/662075696/23600e8a-7d2b-4f5c-aa58-afd28d01f056" width="400"/>][homepage]
 
 [![GitHub tag (latest SemVer)][badge-semver]][releases-github]
 [![license][badge-license]][apache20]

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,21 +3,18 @@
 [![GitHub tag (latest SemVer)][badge-semver]][releases-github]
 [![license][badge-license]][apache20]
 [![Terraform Version][badge-terraform]][releases-terraform]
-[![Join Slack][badge-slack]][slack]
 
-# Examples for using this Mineiros module
+# Examples for using this Amach module
 
 - [public-respository/] Create a public repository on github and set it up with access and webhooks.
 
 <!-- References -->
-[public-respository/]: https://github.com/mineiros-io/terraform-github-repository/tree/main/examples/public-repository
+[public-respository/]: https://github.com/amachsoftware/terraform-github-repository/tree/main/examples/public-repository
 
-[homepage]: https://mineiros.io/?ref=terraform-github-repository
+[homepage]: https://amach.com
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
-[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
-[badge-semver]: https://img.shields.io/github/v/tag/mineiros-io/terraform-github-repository.svg?label=latest&sort=semver
-[releases-github]: https://github.com/mineiros-io/terraform-github-repository/releases
+[badge-semver]: https://img.shields.io/github/v/tag/amachsoftware/terraform-github-repository.svg?label=latest&sort=semver
+[releases-github]: https://github.com/amachsoftware/terraform-github-repository/releases
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0
-[slack]: https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg

--- a/examples/public-repository/README.md
+++ b/examples/public-repository/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+[<img src="https://repository-images.githubusercontent.com/662075696/23600e8a-7d2b-4f5c-aa58-afd28d01f056" width="400"/>][homepage]
 
 [![license][badge-license]][apache20]
 [![Terraform Version][badge-terraform]][releases-terraform]

--- a/examples/public-repository/README.md
+++ b/examples/public-repository/README.md
@@ -2,7 +2,6 @@
 
 [![license][badge-license]][apache20]
 [![Terraform Version][badge-terraform]][releases-terraform]
-[![Join Slack][badge-slack]][slack]
 
 # Create a public repository on Github
 
@@ -14,7 +13,7 @@ branch protection.
 
 ```hcl
 module "repository" {
-  source  = "mineiros-io/repository/github"
+  source  = "amachsoftware/repository/github"
   version = "~> 0.13.0"
 
   module_depends_on = [
@@ -23,7 +22,7 @@ module "repository" {
 
   name               = "my-public-repository"
   description        = "A description of the repository."
-  homepage_url       = "https://github.com/mineiros-io"
+  homepage_url       = "https://github.com/amachsoftware"
   visibility         = "public"
   has_issues         = true
   has_projects       = false
@@ -85,7 +84,7 @@ module "repository" {
 ### Cloning the repository
 
 ```bash
-git clone https://github.com/mineiros-io/terraform-github-repository.git
+git clone https://github.com/amachsoftware/terraform-github-repository.git
 cd terraform-github-repository/examples/public-respository
 ```
 
@@ -108,11 +107,9 @@ Run `terraform destroy` to destroy all resources again.
 
 <!-- References -->
 
-[main.tf]: https://github.com/mineiros-io/terraform-github-repository/blob/main/examples/public-respository/main.tf
-[homepage]: https://mineiros.io/?ref=terraform-github-repository
+[main.tf]: https://github.com/amachsoftware/terraform-github-repository/blob/main/examples/public-respository/main.tf
+[homepage]: https://amach.com
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x%20|0.15%20|0.14%20|%200.13%20|%200.12.20+-623CE4.svg?logo=terraform
-[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0
-[slack]: https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg

--- a/examples/public-repository/main.tf
+++ b/examples/public-repository/main.tf
@@ -6,7 +6,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 module "repository" {
-  source  = "mineiros-io/repository/github"
+  source  = "amachsoftware/repository/github"
   version = "~> 0.13.0"
 
   module_depends_on = [
@@ -15,7 +15,7 @@ module "repository" {
 
   name               = "my-public-repository"
   description        = "A description of the repository."
-  homepage_url       = "https://github.com/mineiros-io"
+  homepage_url       = "https://github.com/amachsoftware"
   visibility         = "public"
   has_issues         = true
   has_projects       = false

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mineiros-io/terraform-github-repository/v2
+module github.com/amachsoftware/terraform-github-repository/v2
 
 go 1.13
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,4 @@
-[<img src="https://raw.githubusercontent.com/mineiros-io/brand/3bffd30e8bdbbde32c143e2650b2faa55f1df3ea/mineiros-primary-logo.svg" width="400"/>][homepage]
+[<img src="https://repository-images.githubusercontent.com/662075696/23600e8a-7d2b-4f5c-aa58-afd28d01f056" width="400"/>][homepage]
 
 [![license][badge-license]][apache20]
 [![Terraform Version][badge-terraform]][releases-terraform]

--- a/test/README.md
+++ b/test/README.md
@@ -2,7 +2,6 @@
 
 [![license][badge-license]][apache20]
 [![Terraform Version][badge-terraform]][releases-terraform]
-[![Join Slack][badge-slack]][slack]
 
 # Tests
 
@@ -62,9 +61,9 @@ Alternatively, you can also run the tests without Docker.
 
 <!-- References -->
 
-[makefile]: https://github.com/mineiros-io/terraform-github-repository/blob/main/Makefile
-[testdirectory]: https://github.com/mineiros-io/terraform-github-repository/tree/main/test
-[homepage]: https://mineiros.io/?ref=terraform-github-repository
+[makefile]: https://github.com/amachsoftware/terraform-github-repository/blob/main/Makefile
+[testdirectory]: https://github.com/amachsoftware/terraform-github-repository/tree/main/test
+[homepage]: https://amach.com
 [terratest]: https://github.com/gruntwork-io/terratest
 [package testing]: https://golang.org/pkg/testing/
 [docker]: https://docs.docker.com/get-started/
@@ -72,7 +71,5 @@ Alternatively, you can also run the tests without Docker.
 [terraform]: https://www.terraform.io/downloads.html
 [badge-license]: https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg
 [badge-terraform]: https://img.shields.io/badge/terraform-1.x-623CE4.svg?logo=terraform
-[badge-slack]: https://img.shields.io/badge/slack-@mineiros--community-f32752.svg?logo=slack
 [releases-terraform]: https://github.com/hashicorp/terraform/releases
 [apache20]: https://opensource.org/licenses/Apache-2.0
-[slack]: https://join.slack.com/t/mineiros-community/shared_invite/zt-ehidestg-aLGoIENLVs6tvwJ11w9WGg

--- a/test/unit-complete/variables.tf
+++ b/test/unit-complete/variables.tf
@@ -19,7 +19,7 @@ variable "delete_branch_on_merge" {
 variable "url" {
   description = "The url of the created repository."
   type        = string
-  default     = "https://github.com/mineiros-io"
+  default     = "https://github.com/amachsoftware"
 }
 
 variable "has_issues" {
@@ -153,7 +153,7 @@ variable "repository_defaults" {
   description = "A map of default settings that can be applied to a repository."
   type        = any
   default = {
-    homepage_url       = "https://github.com/mineiros-io"
+    homepage_url       = "https://github.com/amachsoftware"
     visibility         = "private"
     allow_merge_commit = true
     gitignore_template = "Terraform"


### PR DESCRIPTION
Basic cleanup, mostly involving fixing the many links to the upstream's
website, slack and git repos.

We also preserve the upstream's copyright for the period 2020-2023, but
we claim 2024 onwards.
